### PR TITLE
Correct small typo

### DIFF
--- a/dream.ipynb
+++ b/dream.ipynb
@@ -23,7 +23,7 @@
       "\n",
       "It'll be interesting to see what imagery people are able to generate using the described technique. If you post images to Google+, Facebook, or Twitter, be sure to tag them with **#deepdream** so other researchers can check them out too.\n",
       "\n",
-      "##Dependences\n",
+      "##Dependencies\n",
       "This notebook is designed to have as few dependencies as possible:\n",
       "* Standard Python scientific stack: [NumPy](http://www.numpy.org/), [SciPy](http://www.scipy.org/), [PIL](http://www.pythonware.com/products/pil/), [IPython](http://ipython.org/). Those libraries can also be installed as a part of one of scientific packages for Python, such as [Anaconda](http://continuum.io/downloads) or [Canopy](https://store.enthought.com/).\n",
       "* [Caffe](http://caffe.berkeleyvision.org/) deep learning framework ([installation instructions](http://caffe.berkeleyvision.org/installation.html)).\n",


### PR DESCRIPTION
This commit corrects a minor typo in the `dream.ipynb` file: "Dependences" -> "Dependencies"